### PR TITLE
Feature/update initial calculation

### DIFF
--- a/core/main.cpp
+++ b/core/main.cpp
@@ -122,7 +122,7 @@ void process_can_msg(const char *log_filename){
 
             CANStats& stats = can_stats[dequeuedMsg.can_id];
           
-            if(dequeuedMsg.timestamp - start_time <= 40||stats.count < 201){
+            if(dequeuedMsg.timestamp - start_time <= 40&&stats.count < 201){
                 fprintf(logfile_whole, " 0\n");
                 calc_periodic(dequeuedMsg.can_id, dequeuedMsg.timestamp);
             } else if(susp[dequeuedMsg.can_id]){


### PR DESCRIPTION
초반에 주기 계산을 위한 임계값 수정
* 수정 전: 40초 이전까지의 로그는 모두 주기 계산을 위해 사용
* 수정 후: 40초 이전이지만 200개가 넘은 can id는 탐지 시작